### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	modImplementation "maven.modrinth:lithium:mc1.21-0.12.7"
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0-beta.6")))
+	include(implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0-beta.6")))
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	modImplementation "maven.modrinth:lithium:mc1.21-0.12.7"
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	include(implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0-beta.6")))
+	include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0-beta.6")))
 }
 
 processResources {


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_